### PR TITLE
Added creation of "tmp" directory since without it the initial screenshot will not be created

### DIFF
--- a/bin/hardy-CLI.js
+++ b/bin/hardy-CLI.js
@@ -61,6 +61,7 @@ function hardyCLI() {
     function createTestFolder() {
         fs.writeFileSync('test.feature', "Feature:");
         fs.mkdirSync('screenshots');
+        fs.mkdirSync('screenshots/tmp');
         fs.mkdirSync('step_definitions');
         fs.writeFileSync('step_definitions/custom.js', "");
         fs.writeFileSync('selectors.js', "module.exports = {};");


### PR DESCRIPTION
This is a fix to the `hardy init` functionality so that it also creates the `tmp` directory in the screenshot folder. Otherwise the test runner will fail to create the first screenshot. 
