### PR TITLE
Added filename of image to error message

### DIFF
--- a/features/support/imagetest.js
+++ b/features/support/imagetest.js
@@ -111,7 +111,7 @@ function compare(filename, callback) {
             if (code === 0) {
                 callback();
             } else {
-                callback.fail(new Error("Images don't match"));
+                callback.fail(new Error("Images don't match: " + filename));
             }
         });
     }


### PR DESCRIPTION
With the tests I'm writing, I'm taking a lot of screenshots within a single test run. Having the filename really helps figure out which screenshot doesn't match. 
