### PR TITLE
Preventing Hardy from terminating after missing file

### DIFF
--- a/features/step_definitions/css.js
+++ b/features/step_definitions/css.js
@@ -188,9 +188,15 @@ module.exports = function() {
                 return callback.fail(err);
             }
             if (result.status === 'firstrun') {
-                return callback.fail(new Error("First time this test has been run. New test cases have been created."));
+                console.log("\n -- Notice: --");
+                console.log(" First time this test with selector named:'" +
+                                elementName +
+                                "' has been run and new test cases have been created");
+                return callback();
             }
-            imageTest.compare(result.value, callback);
+            else {
+                imageTest.compare(result.value, callback);
+            }
         });
     };
     this.Then(/^"([^"]*)" should look the same as before$/, shouldLookTheSameAsBefore);


### PR DESCRIPTION
It would be helpful if Hardy didn't terminate after a new baseline image is created
