### PR TITLE
changing parseInt to parseFloat so that non-int measurements don't get chopped off

### DIFF
--- a/features/step_definitions/css.js
+++ b/features/step_definitions/css.js
@@ -123,7 +123,7 @@ module.exports = function() {
 
         var message = elementName + ' should have ' + property + ' of ' + comparator + ' than ' + value;
 
-        value = parseInt(value, 10);
+        value = parseFloat(value, 10);
 
         // Special case for width and height which, if unset, default to auto
         // A few other things do as well but these are the most common.
@@ -134,7 +134,7 @@ module.exports = function() {
                 }
                 measuredValue = measuredValue[property];
                 // compare(value, measuredValue, message, callback);
-                measuredValue = parseInt(measuredValue, 10);
+                measuredValue = parseFloat(measuredValue, 10);
                 message += ' (' + measuredValue + ')';
                 if (comparator === 'less') {
                     try {
@@ -156,7 +156,7 @@ module.exports = function() {
                 if (err) {
                     callback.fail(err);
                 }
-                measuredValue = parseInt(measuredValue, 10);
+                measuredValue = parseFloat(measuredValue, 10);
                 message += ' (' + measuredValue + ')';
                 if (comparator === 'less') {
                     try {


### PR DESCRIPTION
This error occurred when using:
Then "post title" should have "font-size" of greater than "26px"

The problem was that 'post title' has a computed font-size of 26.6666px, but in the greater/less comparison, it does a parseInt which rounds that down to 26. I want to measure that the size is between 26 and 28, and so parseFloat allows me to do that. 

On a side note, I wasn't able to run the tests for some reason on my computer. Hopefully TravisCI doesn't have trouble. 
