### PR TITLE
better error messaging

### DIFF
--- a/features/support/imagetest.js
+++ b/features/support/imagetest.js
@@ -54,18 +54,18 @@ function captureSelector(filename, selector, callback) {
     // First, grab the whole page
     webdriver.screenshot(function(err, result) {
         if(err) {
-            return callback(err, result);
+            return callback("Error capturing screenshot: " + err.orgStatusMessage, result);
         }
 
         // Second, find out where the element is
         webdriver.getLocation(selector, function(err, where) {
             if(err) {
-                return callback(err, result);
+                return callback("Error getting location for selector: \"" + selector + "\" : " + err.orgStatusMessage, result);
             }
             // Third, find out how big the element is
             webdriver.getSize(selector, function(err, size) {
                 if(err) {
-                    return callback(err, result);
+                    return callback("Error getting size for selector: \"" + selector + "\" : " + err.orgStatusMessage, result);
                 }
 
                 // Fourth, save the fullsize image
@@ -75,7 +75,7 @@ function captureSelector(filename, selector, callback) {
                 fs.writeFile(tempFile, buffer, 'base64', function(err) {
 
                     if(err) {
-                        return callback(err, tempFile);
+                        return callback("Error saving screenshot to temp file: " + tempFile, tempFile);
                     }
 
                     // Spawn a separate process to crop the image to the size and position of the element
@@ -86,7 +86,7 @@ function captureSelector(filename, selector, callback) {
                         if (code === 0) {
                             callback(null, {status: /\.diff\./.test(filename)?'success':'firstrun', value: filename});
                         } else {
-                            callback(new Error(code));
+                            callback(new Error("Error cropping image via ghostknife: " + code));
                         }
                     });
 


### PR DESCRIPTION
Providing some better error messaging to the callbacks for imagetest.  Right now, we just pass the err object straight from webdriver, which doesn't get stringified well.

This approach indicates the action that failed, as well as the underlying error message (usually not useful).

To test, try running your tests against a webserver that is not available, or purposefully misname an imageselector to make crop fail.
